### PR TITLE
Fix: always remove URL quotation from links

### DIFF
--- a/mkdocs_roamlinks_plugin/plugin.py
+++ b/mkdocs_roamlinks_plugin/plugin.py
@@ -39,7 +39,7 @@ class AutoLinkReplacer:
         # Absolute URL of the linker
         abs_linker_url = os.path.dirname(
             os.path.join(self.base_docs_url, self.page_url))
-        log.info(filename)
+
         # Find directory URL to target link
         rel_link_url = ''
         # Walk through all files in docs directory to find a matching file


### PR DESCRIPTION
Obsidian.md creates links to other markdown files by using URL quotation so instead `[Link to a file](link to a file.md)` we will see `[Link to a file](link%20to%20a%20file.md)`. If we remove URL quotation manually from a link, then Obsidian.md is not able to support this link and basic functionalities like link jumping and graph display are not working. Since MkDocs can be used as a presentation layer, then a valid place to remove URL quotations is to do it just before parsing markdown files and producing static documentation.

Additionally I have added logging and done some small code cleanup.