### PR TITLE
Fixed strange bug in ROAMLINK_RE which breaks 'alias' match group.

### DIFF
--- a/mkdocs_roamlinks_plugin/plugin.py
+++ b/mkdocs_roamlinks_plugin/plugin.py
@@ -25,7 +25,7 @@ AUTOLINK_RE = r'\[([^\]]+)\]\((([^)/]+\.(md|png|jpg))(#.*)*)\)'
 #       3: alias
 #       4: width
 #       5: height
-ROAMLINK_RE = r"""\[\[(.*?)(\#.*?)?(?:\|([\D][^\|]+[\d]*))?(?:\|(\d+)(?:x(\d+))?)?\]\]"""
+ROAMLINK_RE = r"""\[\[(.*?)(\#.*?)?(?:\|([\D][^\|\]]+[\d]*))?(?:\|(\d+)(?:x(\d+))?)?\]\]"""
 
 class AutoLinkReplacer:
     def __init__(self, base_docs_url, page_url):


### PR DESCRIPTION
I was experiencing a strange bug on my blog where the first few wikilinks were converted properly, but the last wikilink would be broken.

For example: `on Part 1, Part 2, and [Part 3]] and come back here...`

Adding `print` statements to `plugin.py` starting at line 147, I saw:

```
alias1: Part 1
alias1: Part 2
alias1: Part]] and come back here
```

Updating `ROAMLINK_RE` so the third matchgroup also excludes right brackets "]" fixed the issue.  However, it breaks the `test_converts_link_with_square_brackets_in_text` test case, which was a worthwhile tradeoff for me.